### PR TITLE
限制size参数最大为2047像素

### DIFF
--- a/ngx_http_qrcode_module.c
+++ b/ngx_http_qrcode_module.c
@@ -1,6 +1,6 @@
 /*===============================================================
 *   Copyright (C) 2012 All rights reserved.
-*   
+*
 *   Filename：ngx_http_qrcode_module.c
 *   Author ：dcshi
 *   Created：2012-12-09
@@ -45,84 +45,84 @@ ngx_http_qrcode_urlencode_txt(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 static char *
 ngx_http_qrcode_gen(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 
-static ngx_int_t 
+static ngx_int_t
 ngx_http_qrcode_handler(ngx_http_request_t* r);
 
 static void *
 ngx_http_qrcode_create_loc_conf(ngx_conf_t *cf);
 
-static char * 
+static char *
 ngx_http_qrcode_merge_loc_conf(ngx_conf_t* cf, void* parent, void* child);
 
 static char *
-ngx_http_qrcode_cmder(ngx_http_qrcode_cfg_t cfg_code, 
+ngx_http_qrcode_cmder(ngx_http_qrcode_cfg_t cfg_code,
 		ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 
 static ngx_command_t  ngx_http_qrcode_commands[] = {
-	{ 
+	{
 		ngx_string("qrcode_fg_color"),
 		NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
 		ngx_http_qrcode_fg_color,
 		NGX_HTTP_LOC_CONF_OFFSET,
 		offsetof(ngx_http_qrcode_loc_conf_t, fg_color),
 		NULL },
-	{ 
+	{
 		ngx_string("qrcode_bg_color"),
 		NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
 		ngx_http_qrcode_bg_color,
 		NGX_HTTP_LOC_CONF_OFFSET,
 		offsetof(ngx_http_qrcode_loc_conf_t, bg_color),
 		NULL },
-	{ 
+	{
 		ngx_string("qrcode_level"),
 		NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
 		ngx_http_qrcode_level,
 		NGX_HTTP_LOC_CONF_OFFSET,
 		offsetof(ngx_http_qrcode_loc_conf_t, level),
 		NULL },
-	{ 
+	{
 		ngx_string("qrcode_hint"),
 		NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
 		ngx_http_qrcode_hint,
 		NGX_HTTP_LOC_CONF_OFFSET,
 		offsetof(ngx_http_qrcode_loc_conf_t, hint),
 		NULL },
-	{ 
+	{
 		ngx_string("qrcode_size"),
 		NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
 		ngx_http_qrcode_size,
 		NGX_HTTP_LOC_CONF_OFFSET,
 		offsetof(ngx_http_qrcode_loc_conf_t, size),
 		NULL },
-	{ 
+	{
 		ngx_string("qrcode_margin"),
 		NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
 		ngx_http_qrcode_margin,
 		NGX_HTTP_LOC_CONF_OFFSET,
 		offsetof(ngx_http_qrcode_loc_conf_t, margin),
 		NULL },
-	{ 
+	{
 		ngx_string("qrcode_version"),
 		NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
 		ngx_http_qrcode_version,
 		NGX_HTTP_LOC_CONF_OFFSET,
 		offsetof(ngx_http_qrcode_loc_conf_t, version),
 		NULL },
-	{ 
+	{
 		ngx_string("qrcode_casesensitive"),
 		NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
 		ngx_http_qrcode_casesensitive,
 		NGX_HTTP_LOC_CONF_OFFSET,
 		offsetof(ngx_http_qrcode_loc_conf_t, casesensitive),
 		NULL },
-	{ 
+	{
 		ngx_string("qrcode_txt"),
 		NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
 		ngx_http_qrcode_txt,
 		NGX_HTTP_LOC_CONF_OFFSET,
 		offsetof(ngx_http_qrcode_loc_conf_t, txt),
 		NULL },
-	{ 
+	{
 		ngx_string("qrcode_urlencode_txt"),
 		NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
 		ngx_http_qrcode_urlencode_txt,
@@ -130,7 +130,7 @@ static ngx_command_t  ngx_http_qrcode_commands[] = {
 		offsetof(ngx_http_qrcode_loc_conf_t, txt),
 		NULL },
 
-	{ 
+	{
 		ngx_string("qrcode_gen"),
 		NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1|NGX_CONF_NOARGS,
 		ngx_http_qrcode_gen,
@@ -173,7 +173,7 @@ ngx_http_qrcode_create_loc_conf(ngx_conf_t *cf)
 
 	qlcf = ngx_pcalloc(cf->pool, sizeof(ngx_http_qrcode_loc_conf_t));
 	if (qlcf == NULL) {
-		ngx_log_error(NGX_LOG_ERR, cf->log, 0, 
+		ngx_log_error(NGX_LOG_ERR, cf->log, 0,
 				"Mem calloc ngx_http_qrcode_loc_conf_t fail");
 		return NGX_CONF_ERROR;
 	}
@@ -199,7 +199,7 @@ ngx_http_qrcode_create_loc_conf(ngx_conf_t *cf)
 	return qlcf;
 }
 
-static char * 
+static char *
 ngx_http_qrcode_merge_loc_conf(ngx_conf_t* cf, void* parent, void* child) {
 	ngx_http_qrcode_loc_conf_t *pre = parent;
 	ngx_http_qrcode_loc_conf_t *qlcf = child;
@@ -290,16 +290,16 @@ ngx_http_qrcode_urlencode_txt(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 static char *
 ngx_http_qrcode_gen(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 {
-	ngx_http_core_loc_conf_t *core_conf = 
+	ngx_http_core_loc_conf_t *core_conf =
 		ngx_http_conf_get_module_loc_conf(cf, ngx_http_core_module);
 
 	core_conf->handler = ngx_http_qrcode_handler;
-	
+
 	return NGX_CONF_OK;
 }
 
-static ngx_int_t 
-ngx_http_qrcode_handler(ngx_http_request_t* r) 
+static ngx_int_t
+ngx_http_qrcode_handler(ngx_http_request_t* r)
 {
 	ngx_http_qrcode_loc_conf_t *qlcf;
 	ngx_int_t 	code_size;
@@ -309,7 +309,7 @@ ngx_http_qrcode_handler(ngx_http_request_t* r)
 	int 		img_stream_len;
 	u_char		*encoded_txt;
 	ngx_int_t	rc;
-	
+
 	qlcf = ngx_http_get_module_loc_conf(r, ngx_http_qrcode_module);
 
 	/* compile args */
@@ -320,19 +320,19 @@ ngx_http_qrcode_handler(ngx_http_request_t* r)
 	}
 
 	encoded_txt = ngx_pcalloc(r->pool, qlcf->txt.len + 1);
-	ngx_sprintf(encoded_txt, "%V", &qlcf->txt); 	
+	ngx_sprintf(encoded_txt, "%V", &qlcf->txt);
 
 	QRcode *code;
-	code = QRcode_encodeString((char*)encoded_txt, 
+	code = QRcode_encodeString((char*)encoded_txt,
 			qlcf->version, qlcf->level, qlcf->hint, qlcf->casesensitive);
 
 	if(code == NULL) {
-		ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, 
+		ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
 				"Failed to encode content.exception raised by libqrencode: %s", strerror(errno));
 		return NGX_HTTP_INTERNAL_SERVER_ERROR;
 	}
 
-	code_size	= qlcf->size / code->width;
+	code_size	= ((qlcf->size > 2048) ? 1024 : qlcf->size) / code->width;
 	code_size   = (code_size == 0) ? 1 : code_size;
 	img_margin	= qlcf->margin;
 	img_width	= code->width * code_size + 2 * img_margin;
@@ -340,7 +340,7 @@ ngx_http_qrcode_handler(ngx_http_request_t* r)
 	gdImagePtr img;
 	img	= gdImageCreate(img_width, img_width);
 
-	fg_color = gdImageColorAllocate(img, 
+	fg_color = gdImageColorAllocate(img,
 			qlcf->fg_color[0], qlcf->fg_color[1], qlcf->fg_color[2]);
 
 	bg_color = gdImageColorAllocate(img,
@@ -349,18 +349,18 @@ ngx_http_qrcode_handler(ngx_http_request_t* r)
 	gdImageFill(img, 0, 0, bg_color);
 
 	u_char *p = code->data;
-	for (y = 0; y < code->width; y++) 
+	for (y = 0; y < code->width; y++)
 	{
-		for (x = 0; x < code->width; x++) 
+		for (x = 0; x < code->width; x++)
 		{
 			if (*p & 1) {
 				posx = x * code_size + img_margin;
 				posy = y * code_size + img_margin;
 
-				gdImageFilledRectangle(img, posx, posy, 
+				gdImageFilledRectangle(img, posx, posy,
 						posx + code_size, posy + code_size, fg_color);
 			}
-			p++; 
+			p++;
 		}
 	}
 
@@ -380,7 +380,7 @@ ngx_http_qrcode_handler(ngx_http_request_t* r)
 	buffer = ngx_pcalloc(r->pool, sizeof(ngx_buf_t));
 
 	if (buffer == NULL) {
-		ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, 
+		ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
 				"Failed to allocate response buffer");
 		return NGX_HTTP_INTERNAL_SERVER_ERROR;
 	}
@@ -388,7 +388,7 @@ ngx_http_qrcode_handler(ngx_http_request_t* r)
 	//set up the buffer chain
 	ngx_chain_t out;
 	buffer->pos = img_stream;
-	buffer->last = img_stream + img_stream_len; 
+	buffer->last = img_stream + img_stream_len;
 	buffer->memory = 1;
 	buffer->last_buf = 1;
 	out.buf = buffer;
@@ -398,13 +398,13 @@ ngx_http_qrcode_handler(ngx_http_request_t* r)
 }
 
 static char *
-ngx_http_qrcode_cmder(ngx_http_qrcode_cfg_t cfg_code, 
+ngx_http_qrcode_cmder(ngx_http_qrcode_cfg_t cfg_code,
 		ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 {
 	ngx_http_qrcode_loc_conf_t	*qlcf;
     ngx_http_qrcode_cmd_t 		*qr_cmd;
 	ngx_str_t	*raw_args;
-	ngx_array_t **cmds_ptr; 
+	ngx_array_t **cmds_ptr;
 	ngx_array_t **args_ptr;
 	ngx_http_qrcode_arg_template_t	*arg;
 	ngx_http_script_compile_t 		sc;
@@ -412,8 +412,8 @@ ngx_http_qrcode_cmder(ngx_http_qrcode_cfg_t cfg_code,
 
 	qlcf = (ngx_http_qrcode_loc_conf_t *)conf;
 	cmds_ptr = &qlcf->cmds;
-	
-	if (*cmds_ptr == NULL) 
+
+	if (*cmds_ptr == NULL)
 	{
 		*cmds_ptr = ngx_array_create(cf->pool, 1, sizeof(ngx_http_qrcode_cmd_t));
 
@@ -440,7 +440,7 @@ ngx_http_qrcode_cmder(ngx_http_qrcode_cfg_t cfg_code,
 	raw_args = cf->args->elts;
 
 	// we skip the first arg and start from the second
-	for (i = 1 ; i < cf->args->nelts; i++) 
+	for (i = 1 ; i < cf->args->nelts; i++)
 	{
 		arg = ngx_array_push(*args_ptr);
 


### PR DESCRIPTION
如果size参数，设置过大，造成响应缓慢，最终导致nginx崩溃,防止恶意参数攻击.
